### PR TITLE
use yum package resource (was rpm)

### DIFF
--- a/libraries/nrpe_installation_package.rb
+++ b/libraries/nrpe_installation_package.rb
@@ -59,7 +59,7 @@ module NrpeNgCookbook
           package_version = options[:version]
           package options[:package] do
             notifies :delete, init_file, :immediately
-            provider Chef::Provider::Package::Rpm if node.platform_family?('rhel')
+            provider Chef::Provider::Package::Yum if node.platform_family?('rhel')
             if node.platform_family?('debian')
               options '-o Dpkg::Options::=--path-exclude=/etc/nagios/*'
             end


### PR DESCRIPTION
currently with the rpm provider it errors with the following:

```
         * nrpe_installation[nrpe] action create
           * file[/etc/init.d/nrpe] action nothing (skipped due to action :nothing)
           * dpkg_autostart[nagios-nrpe-server] action create (skipped due to only_if)
           * yum_package[nrpe, nagios-plugins-disk, nagios-plugins-load, nagios-plugins-procs, nagios-plugins-users] action install
             * Package nrpe, nagios-plugins-disk, nagios-plugins-load, nagios-plugins-procs, nagios-plugins-users not found: 
             ================================================================================
             Error executing action `install` on resource 'yum_package[nrpe, nagios-plugins-disk, nagios-plugins-load, nagios-plugin
s-procs, nagios-plugins-users]'
             ================================================================================

             Chef::Exceptions::Package
             -------------------------
             Package nrpe, nagios-plugins-disk, nagios-plugins-load, nagios-plugins-procs, nagios-plugins-users not found: 

             Cookbook Trace:
             ---------------
             /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
             /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/notifying_block.rb:69:in `notifying_block'
             /tmp/kitchen/cache/cookbooks/nrpe-ng/libraries/nrpe_installation_package.rb:40:in `action_create'
             /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'

             Resource Declaration:
             ---------------------
             # In /tmp/kitchen/cache/cookbooks/nrpe-ng/libraries/nrpe_installation_package.rb

       60:           package options[:package] do
       61:             notifies :delete, init_file, :immediately
       62:             provider Chef::Provider::Package::Rpm if node.platform_family?('rhel')
       63:             if node.platform_family?('debian')
       64:               options '-o Dpkg::Options::=--path-exclude=/etc/nagios/*'
       65:             end
       66:             version package_version

             Compiled Resource:
             ------------------
             # Declared in /tmp/kitchen/cache/cookbooks/nrpe-ng/libraries/nrpe_installation_package.rb:60:in `block in action_create'

             yum_package("nrpe, nagios-plugins-disk, nagios-plugins-load, nagios-plugins-procs, nagios-plugins-users") do
        package_name ["nrpe", "nagios-plugins-disk", "nagios-plugins-load", "nagios-plugins-procs", "nagios-plugins-users"]
        provider Chef::Provider::Package::Rpm
        action [:install]
        retries 0
        retry_delay 2
        default_guard_interpreter :default
        declared_type :package
        cookbook_name "nrpe-ng"
        version ["2.15-7.el5", "1.4.15-2.el5", "1.4.15-2.el5", "1.4.15-2.el5", "1.4.15-2.el5"]
             end

             Platform:
             ---------
             x86_64-linux
```
