### PR TITLE
allow nrpe_check to override plugin_path, and dont force nagios-plugins-*

### DIFF
--- a/libraries/nrpe_check.rb
+++ b/libraries/nrpe_check.rb
@@ -35,11 +35,14 @@ module NrpeNgCookbook
       # @!attribute critical_condition
       # @return [String]
       attribute(:critical_condition, kind_of: String)
+      # @!attribute plugin_path
+      # @return [String]
+      attribute(:plugin_path, kind_of: String, default: lazy { parent.plugin_path })
 
       # @return [String]
       # @api private
       def default_command
-        ::File.join(parent.plugin_path, command_name)
+        ::File.join(plugin_path, command_name)
       end
 
       # @return [String]

--- a/libraries/nrpe_installation_package.rb
+++ b/libraries/nrpe_installation_package.rb
@@ -88,8 +88,8 @@ module NrpeNgCookbook
       # @api private
       def self.default_package_name(node)
         case node.platform
-        when 'centos', 'redhat' then %w{nrpe nagios-plugins-disk nagios-plugins-load nagios-plugins-procs nagios-plugins-users}
-        when 'ubuntu' then %w{nagios-nrpe-server nagios-plugins-basic}
+        when 'centos', 'redhat' then %w{nrpe}
+        when 'ubuntu' then %w{nagios-nrpe-server}
         end
       end
 
@@ -100,15 +100,15 @@ module NrpeNgCookbook
         case node.platform
         when 'redhat', 'centos'
           case node.platform_version.to_i
-          when 5 then %w{2.15-7.el5 1.4.15-2.el5 1.4.15-2.el5 1.4.15-2.el5 1.4.15-2.el5}
-          when 6 then %w{2.15-7.el6 2.0.3-3.el6 2.0.3-3.el6 2.0.3-3.el6 2.0.3-3.el6}
-          when 7 then %w{2.15-7.el7 2.0.3-3.el7 2.0.3-3.el7 2.0.3-3.el7 2.0.3-3.el7}
+          when 5 then %w{2.15-7.el5}
+          when 6 then %w{2.15-7.el6}
+          when 7 then %w{2.15-7.el7}
           end
         when 'ubuntu'
           case node.platform_version.to_i
-          when 12 then %w{2.12-5ubuntu1 1.4.15-5ubuntu3}
-          when 14 then %w{2.15-0ubuntu1 1.5-3ubuntu1}
-          when 16 then %w{2.15-1ubuntu1 2.1.2-2ubuntu2}
+          when 12 then %w{2.12-5ubuntu1}
+          when 14 then %w{2.15-0ubuntu1}
+          when 16 then %w{2.15-1ubuntu1}
           end
         end
       end


### PR DESCRIPTION
allow nrpe_check to override plugin_path;

```
nrpe_check 'check_load' do
  warning_condition '6'
  critical_condition '10'
  plugin_path '/some/other/plugin_path'
end
```

also removed nagios-plugins-\* pkg installs since those should be up to the user.
