### PR TITLE
nrpe_installation should notify restart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,7 @@ end
 
 install = nrpe_installation node['nrpe-ng']['service_name'] do
   version ''
-  notifies :reload, "nrpe_service[#{name}]", :delayed
+  notifies :restart, "nrpe_service[#{name}]", :delayed
 end
 
 config = nrpe_config node['nrpe-ng']['service_name'] do


### PR DESCRIPTION
nrpe_installation should notify restart instead of reload, this will also handle the following scenario during an upgrade when the system thinks nrpe is running when it isn't and thus cant reload:

```
       [2016-11-02T15:25:19+00:00] ERROR: nrpe_service[nrpe] (nrpe-ng::default line 26) had an error: Mixlib::ShellOut::ShellCommandFailed: poise_service[nrpe] (/tmp/kitchen/cache/cookbooks/nrpe-ng/recipes/default.rb line 26) had an error: Mixlib::ShellOut::ShellCommandFailed: service[nrpe] (/tmp/kitchen/cache/cookbooks/nrpe-ng/recipes/default.rb line 26) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
       ---- Begin output of /sbin/reload nrpe ----
       STDOUT: 
       STDERR: reload: Not running
       ---- End output of /sbin/reload nrpe ----
       Ran /sbin/reload nrpe returned 1
```