### PR TITLE
Turn off backup of the remote_file download 

### DIFF
--- a/libraries/nrpe_installation_package.rb
+++ b/libraries/nrpe_installation_package.rb
@@ -94,6 +94,7 @@ module NrpeNgCookbook
                                remote_file ::File.basename(options[:package_url]) do
                                  path ::File.join(Chef::Config[:file_cache_path], name)
                                  source options[:package_url]
+                                 backup false
                                end.path
                              end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures NRPE.'
 long_description 'Application cookbook which installs and configures NRPE.'
-version '1.1.0'
+version '1.1.1'
 issues_url 'https://github.com/johnbellone/nrpe-ng-cookbook/issues'
 source_url 'https://github.com/johnbellone/nrpe-ng-cookbook'
 


### PR DESCRIPTION
so it doesn't get copied to /var/chef/backup/var/chef/cache as well.

This is (along with a number of other packages) causing /var/chef/backup/var/chef/cache to overfill.