### PR TITLE
Add basic support for configuring via attributes for Solaris/AIX.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,7 +62,13 @@ platforms:
 
 suites:
   - name: default
+    attributes:
+      nrpe:
+        config:
+          debug: true
   - name: archive
     attributes:
       nrpe:
-        install_method: archive
+        provider: archive
+        config:
+          debug: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0]
 
 ### Added
 - Changelog
 
 ### Changed
+- Add basic support for configuring via node attributes for Solaris/AIX.
 - upstart: Fix issue where reboot fails to start nrpe due to run directory not created.
 
 ## [2.0.1] - 2017-07-13

--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ Additionally, the platforms below are also known to work:
 
 | Attribute Name | Type | Default Value | Description |
 | -------------- | ---- | ------------- | ----------- |
-| node['nrpe']['install']['method'] | String | package | Sets the installation method. |
+| node['nrpe']['archive']['version'] | String | (see [attributes/default.rb][4]) | Sets the verison of nrpe archive. |
+| node['nrpe']['archive']['checksum'] | String | (see [attributes/default.rb][4]) | Sets the nrpe archive checksum. |
+| node['nrpe']['archive']['url'] | String | (see [attributes/default.rb][4]) | Sets the nrpe archive download URL. |
 | node['nrpe']['config_file'] | String | /etc/nagios/nrpe.cfg | Sets the path for base nrpe configuration. |
+| node['nrpe']['nrpe_plugins'] | String | (see [attributes/default.rb][4]) | |
+| node['nrpe']['package']['packages'] | String, Array | (see [attributes/default.rb][4]) | Sets the path for nrpe plugins. |
+| node['nrpe']['program'] | String | /usr/sbin/nrpe | Sets the location or nrpe program. |
+| node['nrpe']['provider'] | String | package | Sets the nrpe installation provider. |
 | node['nrpe']['service_name'] | String | nrpe | Sets the name of the service. |
 | node['nrpe']['service_user'] | String | nrpe | Sets the service username. |
 | node['nrpe']['service_group'] | String | nrpe | Sets the service groupname. |
@@ -39,11 +45,39 @@ Additionally, the platforms below are also known to work:
 | ------------- | ----------- |
 | nrpe_config | Manages the configuration of the nrpe client. |
 | nrpe_check | Manages an active check for the nrpe client. |
-| nrpe_installation_archive | Compiles the nrpe client from an archive. |
-| nrpe_installation_omnibus | Installs the nrpe client from an [Omnibus package][3]. |
+| [nrpe_installation_archive](#Archive-Installation] | Compiles the nrpe client from an archive. |
+| [nrpe_installation_omnibus](#Omnibus-Installation) | Installs the nrpe client from an [Omnibus package][3]. |
 | nrpe_installation_package | Installs the nrpe client from a system package. |
+
+### Archive Installation
+
+``` ruby
+node.override['nrpe']['config']['debug'] = true
+
+node.override['nrpe']['provider'] = 'archive'
+node.override['nrpe']['archive']['version'] = '2.0.0'
+include_recipe 'blp-nrpe::default'
+```
+
+### Omnibus Installation
+
+``` ruby
+include_recipe 'chef-sugar::default'
+
+node.override['nrpe']['config']['debug'] = true
+
+node.override['nrpe']['provider'] = 'omnibus'
+node.override['nrpe']['omnibus']['package_source'] = 'https://artifactory.bigco.com/.../inf-nrpe-3.0.1.pkg' if solaris?
+node.override['nrpe']['omnibus']['package_source'] = 'https://artifactory.bigco.com/.../inf-nrpe-3.0.1.bff' if aix?
+node.override['nrpe']['omnibus']['package_source'] = 'https://artifactory.bigco.com/.../inf-nrpe-3.0.1.rpm' if rhel?
+node.override['nrpe']['omnibus']['package_source'] = 'https://artifactory.bigco.com/.../inf-nrpe-3.0.1.deb' if ubuntu?
+node.override['nrpe']['program'] = '/opt/inf/inf-nrpe/sbin/nrpe'
+node.override['nrpe']['nrpe_plugins'] = '/opt/inf/inf-nrpe/lib/nagios/plugins'
+include_recipe 'blp-nrpe::default'
+```
 
 [0]: https://github.com/test-kitchen/test-kitchen
 [1]: https://en.wikipedia.org/wiki/Nagios#NRPE
 [2]: https://github.com/bloomberg-cookbooks/nrpe/blob/master/test/integration/default/default_spec.rb
 [3]: https://github.com/chef/omnibus
+[4]: https://github.com/bloomberg-cookbooks/nrpe/blob/master/attributes/default.rb

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,11 +5,27 @@
 # Copyright 2015-2017, Bloomberg Finance L.P.
 #
 
-default['nrpe']['install']['provider'] = 'package'
+default['nrpe']['provider'] = 'package'
+default['nrpe']['program'] = '/usr/sbin/nrpe'
+default['nrpe']['config_file'] = '/etc/nagios/nrpe.cfg'
+default['nrpe']['config'] = {}
 
 default['nrpe']['service_name'] = 'nrpe'
 default['nrpe']['service_user'] = 'nrpe'
 default['nrpe']['service_group'] = 'nrpe'
 default['nrpe']['service_home'] = '/var/run/nrpe'
 
-default['nrpe']['config_file'] = '/etc/nagios/nrpe.cfg'
+if platform_family? 'debian'
+  default['nrpe']['nrpe_plugins'] = '/usr/lib/nagios/plugins'
+
+  default['nrpe']['package']['packages'] = %w(nagios-nrpe-server nagios-plugins-basic)
+elsif platform_family? 'rhel'
+  default['nrpe']['nrpe_plugins'] = '/usr/lib64/nagios/plugins'
+
+  default['nrpe']['package']['packages'] = %w(nrpe nagios-plugins)
+end
+
+default['nrpe']['archive']['prefix'] = '/opt/nrpe'
+default['nrpe']['archive']['version'] = '3.0.1'
+default['nrpe']['archive']['checksum'] = '8f56da2d74f6beca1a04fe04ead84427e582b9bb88611e04e290f59617ca3ea3'
+default['nrpe']['archive']['url'] = 'https://github.com/NagiosEnterprises/nrpe/releases/download/%{version}/nrpe-%{version}.tar.gz'

--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -7,12 +7,3 @@
 
 class FalseClass; def to_i; 0; end end
 class TrueClass; def to_i; 1; end end
-
-module NrpeCookbook
-  module Resource
-    def default_nrpe_plugins
-      return '/usr/lib/nagios/plugins' if platform_family? 'debian'
-      '/usr/lib64/nagios/plugins'
-    end
-  end
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name 'blp-nrpe'
-version '2.0.2'
-maintainer 'Bloomberg Infrastructure Engineering'
+version '2.1.0'
+maintainer 'Bloomberg Finance L.P.'
 maintainer_email 'chef@bloomberg.net'
 license 'Apache-2.0'
 description 'Installs and configures nrpe.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,7 @@ config = nrpe_config node['nrpe']['service_name'] do
   path node['nrpe']['config_file']
   owner node['nrpe']['service_user']
   group node['nrpe']['service_group']
+  node['nrpe']['config'].each_pair { |k, v| send(k, v) }
   notifies :reload, "poise_service[#{name}]", :delayed
 end
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -5,8 +5,6 @@
 # Copyright 2015-2017, Bloomberg Finance L.P.
 #
 
-include NrpeCookbook::Resource
-
 provides :nrpe_check
 
 property :command_name, String, name_property: true
@@ -15,12 +13,11 @@ property :parameters, [String, Array]
 property :warning_condition, String
 property :critical_condition, String
 
-# TODO: Move into some kind of helpers and include into resource.
 property :include_path, String, default: '/etc/nagios/nrpe.d'
-property :service_name, String, default: 'nrpe'
-property :service_user, String, default: 'nrpe'
-property :service_group, String, default: 'nrpe'
-property :nrpe_plugins, String, default: lazy { default_nrpe_plugins }
+property :service_name, String, default: lazy { node['nrpe']['service_name'] }
+property :service_user, String, default: lazy { node['nrpe']['service_user'] }
+property :service_group, String, default: lazy { node['nrpe']['service_group'] }
+property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
 
 def content
   ["command[#{command_name}]=#{command}"].tap do |c|
@@ -32,13 +29,6 @@ end
 
 def config_path
   ::File.join(include_path, "#{command_name}.cfg")
-end
-
-load_current_value do
-  current_value_does_not_exist! if node.run_state['nrpe'].nil?
-  service_name node.run_state['nrpe']['service_name']
-  service_user node.run_state['nrpe']['service_user']
-  service_group node.run_state['nrpe']['service_group']
 end
 
 action :add do

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -8,8 +8,8 @@
 provides :nrpe_config
 
 property :path, String, name_property: true
-property :owner, String, default: 'nrpe'
-property :group, String, default: 'nrpe'
+property :owner, String, default: lazy { node['nrpe']['service_user'] }
+property :group, String, default: lazy { node['nrpe']['service_group'] }
 property :mode, String, default: '0440'
 
 # @see https://github.com/NagiosEnterprises/nrpe/blob/master/sample-config/nrpe.cfg.in

--- a/resources/installation_archive.rb
+++ b/resources/installation_archive.rb
@@ -5,30 +5,22 @@
 # Copyright 2015-2017, Bloomberg Finance L.P.
 #
 
-include NrpeCookbook::Resource
-
 provides :nrpe_installation_archive
 provides :nrpe_installation do |node|
-  node['nrpe']['install']['provider'] == 'archive'
+  node['nrpe']['provider'] == 'archive'
 end
 
-property :version, String, default: '3.0.1'
-property :prefix, String, default: '/opt/nrpe'
-property :archive_url, String, default: 'https://github.com/NagiosEnterprises/nrpe/releases/download/%{version}/nrpe-%{version}.tar.gz'
-property :archive_checksum, String, default: lazy { default_archive_checksum }
-property :service_user, String, default: 'nrpe'
-property :service_group, String, default: 'nrpe'
-property :nrpe_plugins, String, default: '/usr/local/lib64/nagios/plugins'
+property :version, String, default: lazy { node['nrpe']['archive']['version'] }
+property :prefix, String, default: lazy { node['nrpe']['archive']['prefix'] }
+property :archive_url, String, default: lazy { node['nrpe']['archive']['url'] }
+property :archive_checksum, String, default: lazy { node['nrpe']['archive']['checksum'] }
+property :service_user, String, default: lazy { node['nrpe']['service_user'] }
+property :service_group, String, default: lazy { node['nrpe']['service_group'] }
+property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
 property :nrpe_program, String, default: lazy { ::File.join(static_folder, 'sbin', 'nrpe') }
 
 def static_folder
   ::File.join(prefix, version)
-end
-
-def default_archive_checksum
-  case version
-  when '3.0.1' then '8f56da2d74f6beca1a04fe04ead84427e582b9bb88611e04e290f59617ca3ea3'
-  end
 end
 
 action :install do
@@ -48,7 +40,7 @@ action :install do
     recursive true
   end
 
-  url = format(new_resource.archive_url, version: new_resource.version)
+  url = format(new_resource.archive_url, new_resource.version)
   poise_archive url do
     notifies :run, 'bash[make-nrpe]', :immediately
     destination new_resource.static_folder

--- a/resources/installation_omnibus.rb
+++ b/resources/installation_omnibus.rb
@@ -5,18 +5,16 @@
 # Copyright 2015-2017, Bloomberg Finance L.P.
 #
 
-include NrpeCookbook::Resource
-
 provides :nrpe_installation_omnibus
 provides :nrpe_installation do |node|
-  node['nrpe']['install']['provider'] == 'omnibus'
+  node['nrpe']['provider'] == 'omnibus'
 end
 
-property :package_source, [String, Array], required: true
-property :service_user, String, default: 'nrpe'
-property :service_group, String, default: 'nrpe'
-property :nrpe_program, String, required: true
-property :nrpe_plugins, String, default: '/etc/nagios/nrpe.d'
+property :service_user, String, default: lazy { node['nrpe']['service_user'] }
+property :service_group, String, default: lazy { node['nrpe']['service_group'] }
+property :nrpe_program, String, default: lazy { node['nrpe']['program'] }
+property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
+property :package_source, String, default: lazy { node['nrpe']['omnibus']['package_source'] }
 
 action :install do
   directory new_resource.nrpe_plugins do

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -5,23 +5,16 @@
 # Copyright 2015-2017, Bloomberg Finance L.P.
 #
 
-include NrpeCookbook::Resource
-
 provides :nrpe_installation_package
 provides :nrpe_installation do |node|
-  node['nrpe']['install']['provider'] == 'package'
+  node['nrpe']['provider'] == 'package'
 end
 
-property :packages, [String, Array], default: lazy { default_packages }
-property :service_user, String, default: 'nrpe'
-property :service_group, String, default: 'nrpe'
-property :nrpe_program, String, default: '/usr/sbin/nrpe'
-property :nrpe_plugins, String, default: lazy { default_nrpe_plugins }
-
-def default_packages
-  return %w(nagios-nrpe-server nagios-plugins-basic) if platform_family? 'debian'
-  %w(nrpe nagios-plugins)
-end
+property :service_user, String, default: lazy { node['nrpe']['service_user'] }
+property :service_group, String, default: lazy { node['nrpe']['service_group'] }
+property :nrpe_program, String, default: lazy { node['nrpe']['program'] }
+property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
+property :packages, [String, Array], default: lazy { node['nrpe']['package']['packages'] }
 
 action :install do
   directory new_resource.nrpe_plugins do

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -16,7 +16,7 @@ RuntimeDirectory=nrpe
 RuntimeDirectoryMode=0775
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStopPost=/bin/rm -f <%= @pidfile %>
+ExecStopPost=/bin/rm -f <%= @pid_file %>
 TimeoutStopSec=60
 User=<%= @user %>
 Group=<%= @group %>

--- a/templates/default/sysvinit.sh.erb
+++ b/templates/default/sysvinit.sh.erb
@@ -24,7 +24,7 @@ NRPE_BIN="<%= @environment['PROGRAM'] %>"
 NRPE_CFG="<%= @environment['CONFIG_FILE'] %>"
 LOCK_DIR=/var/lock/subsys
 LOCK_FILE="/var/lock/subsys/<%= @service_name %>"
-PID_FILE="<%= @pidfile %>"
+PID_FILE="<%= @pid_file %>"
 
 test -x $NRPE_BIN || exit 5
 


### PR DESCRIPTION
/cc @acaiafa @sparciii 
We install the nrpe client using an Omnibus package. The provider that
is supplied requires input properties but there is no easy way to use
this with the provided default recipe. This commit mainly adds support
for using node attributes to drive default configuration.