### PR TITLE
Add flexibility for system packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Additionally, the platforms below are also known to work:
 | node['nrpe']['service_user'] | String | nrpe | Sets the service username. |
 | node['nrpe']['service_group'] | String | nrpe | Sets the service groupname. |
 | node['nrpe']['service_home'] | String | /var/run/nrpe | Sets the service directory. |
+| node['nrpe']['service_resource'] | String | `poise_service` | Set the service resource to use to control/reload the NRPE service |
 
 ## Custom Resources
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,8 @@ default['nrpe']['service_user'] = 'nrpe'
 default['nrpe']['service_group'] = 'nrpe'
 default['nrpe']['service_home'] = '/var/run/nrpe'
 
+default['nrpe']['service_resource'] = 'poise_service'
+
 if platform_family? 'debian'
   default['nrpe']['nrpe_plugins'] = '/usr/lib/nagios/plugins'
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -43,13 +43,25 @@ action :add do
     owner new_resource.service_user
     group new_resource.service_group
     mode '0440'
-    notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
+    if node['nrpe']['provider'] == 'omnibus' || node['nrpe']['provider'] == 'archive'
+      # Use poise for omnibus and archive
+      notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
+    else
+      # For everything else, we're using the system package so use the default service resource
+      notifies :reload, "service[#{new_resource.service_name}]", :delayed
+    end
   end
 end
 
 action :remove do
   file new_resource.config_path do
     action :delete
-    notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
+    if node['nrpe']['provider'] == 'omnibus' || node['nrpe']['provider'] == 'archive'
+      # Use poise for omnibus and archive
+      notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
+    else
+      # For everything else, we're using the system package so use the default service resource
+      notifies :reload, "service[#{new_resource.service_name}]", :delayed
+    end
   end
 end

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -15,6 +15,7 @@ property :critical_condition, String
 
 property :include_path, String, default: '/etc/nagios/nrpe.d'
 property :service_name, String, default: lazy { node['nrpe']['service_name'] }
+property :service_resource, String, default: lazy { node['nrpe']['service_resource'] }
 property :service_user, String, default: lazy { node['nrpe']['service_user'] }
 property :service_group, String, default: lazy { node['nrpe']['service_group'] }
 property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
@@ -43,25 +44,13 @@ action :add do
     owner new_resource.service_user
     group new_resource.service_group
     mode '0440'
-    if node['nrpe']['provider'] == 'omnibus' || node['nrpe']['provider'] == 'archive'
-      # Use poise for omnibus and archive
-      notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
-    else
-      # For everything else, we're using the system package so use the default service resource
-      notifies :reload, "service[#{new_resource.service_name}]", :delayed
-    end
+    notifies :reload, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
   end
 end
 
 action :remove do
   file new_resource.config_path do
     action :delete
-    if node['nrpe']['provider'] == 'omnibus' || node['nrpe']['provider'] == 'archive'
-      # Use poise for omnibus and archive
-      notifies :reload, "poise_service[#{new_resource.service_name}]", :delayed
-    else
-      # For everything else, we're using the system package so use the default service resource
-      notifies :reload, "service[#{new_resource.service_name}]", :delayed
-    end
+    notifies :reload, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -24,6 +24,7 @@ property :connection_timeout, Integer, default: 300
 property :debug, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :dont_blame_nrpe, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :include_dir, String, default: '/etc/nagios/nrpe.d'
+property :pid_file, String, default: '/var/run/nrpe/nrpe.pid'
 property :listen_queue_size, Integer, default: 5
 property :log_facility, String, default: 'daemon'
 property :server_address, String, default: '127.0.0.1'


### PR DESCRIPTION
This pull features a few requests which will allow the cookbook to be used with OS system packages, that come with various startup/service scripts depending on the OS. One can now override the `poise_service` resource to the regular `service` resource in this case. PID file can also now be set. 