### PR TITLE
github: Add pull request, issue and contributing documents.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+Please refer to
+https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Cookbook version
+[Version of the cookbook where you are encountering the issue]
+
+### Chef-client version
+[Version of chef-client in your environment]
+
+### Platform Details
+[Operating system distribution and release version. Cloud provider if running in the cloud]
+
+### Scenario:
+[What you are trying to achieve and you can't?]
+
+### Steps to Reproduce:
+[If you are filing an issue what are the things we need to do in order to repro your problem? How are you using this cookbook or any resources it includes?]
+
+### Expected Result:
+[What are you expecting to happen as the consequence of above reproduction steps?]
+
+### Actual Result:
+[What actually happens after the reproduction steps? Include the error output or a link to a gist if possible.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Description
+
+[Describe what this change achieves]
+
+### Issues Resolved
+
+[List any existing issues this PR resolves]
+
+### Check List
+
+- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented in the README if applicable
+- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


### PR DESCRIPTION
These templates follow the Chef Community guidelines.