### PR TITLE
Remove explicit nrpe_config :reload in default recipe.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,6 @@ config = nrpe_config node['nrpe']['service_name'] do
   owner node['nrpe']['service_user']
   group node['nrpe']['service_group']
   node['nrpe']['config'].each_pair { |k, v| send(k, v) }
-  notifies :reload, "poise_service[#{name}]", :delayed
 end
 
 poise_service node['nrpe']['service_name'] do


### PR DESCRIPTION
/cc @bloomberg-cookbooks/systems-engineering 

### Description

The notifies block inside of the default recipe is redundant because we handle this inside of the custom resource. This just removes it so that it does not confuse anyone. Its important to note that we do **not** do a notifies inside of any of the installation resources. That is confusing and we may want to revisit it later.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
