### PR TITLE
resources config.rb , check.rb changed

### DIFF
--- a/resources/check.rb
+++ b/resources/check.rb
@@ -44,13 +44,13 @@ action :add do
     owner new_resource.service_user
     group new_resource.service_group
     mode '0440'
-    notifies :reload, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
+    notifies :restart, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
   end
 end
 
 action :remove do
   file new_resource.config_path do
     action :delete
-    notifies :reload, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
+    notifies :restart, "#{new_resource.service_resource}[#{new_resource.service_name}]", :delayed
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -27,7 +27,7 @@ property :include_dir, String, default: '/etc/nagios/nrpe.d'
 property :pid_file, String, default: '/var/run/nrpe/nrpe.pid'
 property :listen_queue_size, Integer, default: 5
 property :log_facility, String, default: 'daemon'
-property :server_address, String
+property :server_address, String, default: '127.0.0.1'
 property :server_port, Integer, default: 5_666
 property :nrpe_user, String, default: lazy { owner }
 property :nrpe_group, String, default: lazy { group }

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -24,7 +24,7 @@ property :connection_timeout, Integer, default: 300
 property :debug, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :dont_blame_nrpe, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :include_dir, String, default: '/etc/nagios/nrpe.d'
-property :pid_file, String, default: '/var/run/nrpe/nrpe.pid'
+property :pid_file, String, default: '/var/run/nrpe.pid'
 property :listen_queue_size, Integer, default: 5
 property :log_facility, String, default: 'daemon'
 property :server_address, String, default: '127.0.0.1'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -27,7 +27,7 @@ property :include_dir, String, default: '/etc/nagios/nrpe.d'
 property :pid_file, String, default: '/var/run/nrpe/nrpe.pid'
 property :listen_queue_size, Integer, default: 5
 property :log_facility, String, default: 'daemon'
-property :server_address, String, default: '127.0.0.1'
+property :server_address, String
 property :server_port, Integer, default: 5_666
 property :nrpe_user, String, default: lazy { owner }
 property :nrpe_group, String, default: lazy { group }

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -24,7 +24,7 @@ property :connection_timeout, Integer, default: 300
 property :debug, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :dont_blame_nrpe, [true, false, 0, 1], default: false, coerce: proc { |v| v.to_i }
 property :include_dir, String, default: '/etc/nagios/nrpe.d'
-property :pid_file, String, default: '/var/run/nrpe.pid'
+property :pid_file, String, default: '/var/run/nrpe/nrpe.pid'
 property :listen_queue_size, Integer, default: 5
 property :log_facility, String, default: 'daemon'
 property :server_address, String, default: '127.0.0.1'


### PR DESCRIPTION
### Description

check.rb - reload changed to refresh
config.rb - pid_file changed. This was needed since solaris keeps nrpe pid in a file and refers to the file for restart of nrpe service.

### Issues Resolved

service reload is not supported on Solaris/AIX, only refresh is supported.
refresh works on Linux/Solaris/AIX.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
