### PR TITLE
Changed '--warning' and '--critical' options to '-w' && '-c' respectively

### DIFF
--- a/resources/check.rb
+++ b/resources/check.rb
@@ -10,8 +10,6 @@ provides :nrpe_check
 property :command_name, String, name_property: true
 property :command, String, default: lazy { ::File.join(nrpe_plugins, command_name) }
 property :parameters, [String, Array]
-property :warn, String
-property :crit, String
 property :warning_condition, String
 property :critical_condition, String
 
@@ -24,10 +22,8 @@ property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
 
 def content
   ["command[#{command_name}]=#{command}"].tap do |c|
-    c << ['-w', warn] if warn
-    c << ['-c', crit] if crit
-    c << ['--warning', warning_condition] if warning_condition
-    c << ['--critical', critical_condition] if critical_condition
+    c << ['-w', warning_condition] if warning_condition
+    c << ['-c', critical_condition] if critical_condition
     c << [parameters] if parameters
   end.flatten.join(' ').concat("\n")
 end

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -10,6 +10,8 @@ provides :nrpe_check
 property :command_name, String, name_property: true
 property :command, String, default: lazy { ::File.join(nrpe_plugins, command_name) }
 property :parameters, [String, Array]
+property :warn, String
+property :crit, String
 property :warning_condition, String
 property :critical_condition, String
 
@@ -22,8 +24,10 @@ property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
 
 def content
   ["command[#{command_name}]=#{command}"].tap do |c|
-    c << ['-w', warning_condition] if warning_condition
-    c << ['-c', critical_condition] if critical_condition
+    c << ['-w', warn] if warn
+    c << ['-c', crit] if crit
+    c << ['--warning', warning_condition] if warning_condition
+    c << ['--critical', critical_condition] if critical_condition
     c << [parameters] if parameters
   end.flatten.join(' ').concat("\n")
 end

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -22,8 +22,8 @@ property :nrpe_plugins, String, default: lazy { node['nrpe']['nrpe_plugins'] }
 
 def content
   ["command[#{command_name}]=#{command}"].tap do |c|
-    c << ['--warning', warning_condition] if warning_condition
-    c << ['--critical', critical_condition] if critical_condition
+    c << ['-w', warning_condition] if warning_condition
+    c << ['-c', critical_condition] if critical_condition
     c << [parameters] if parameters
   end.flatten.join(' ').concat("\n")
 end


### PR DESCRIPTION
The short format is the most common format used in most generic plugins
By using the '--warning/--critical' most of the plugins won't work

For scripts that support only '--warning/--critical' the check can be build by using the attribute 'parameters'.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
