### PR TITLE
Add tests for Ubuntu 18.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,6 +59,15 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
+        
+  - name: ubuntu-18.04
+    named_run_list: debian
+    driver:
+      image: ubuntu:18.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
 
 suites:
   - name: default


### PR DESCRIPTION
### Description

Add Ubuntu 18.04 platform for kitchen tests
