### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'blp-nrpe'
-version '2.2.0'
+version '2.2.1'
 maintainer 'Bloomberg Finance L.P.'
 maintainer_email 'chef@bloomberg.net'
 license 'Apache-2.0'


### PR DESCRIPTION
bump version for release to supermarket (code on supermarket does not match master here @lozzd

### Description

It was discovered the code hosted on supermarket was released as 2.2.0 but the code in master was not released but version shows as 2.2.0.

This change will bump the version and then release it to supermarket.chef.io as 2.2.1

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
