### PR TITLE
Skip allow_bash_commands option for Solaris machines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.2.2 - 2021-04-29
+
+### Changed
+- solaris: skip allow_bash_commands option in nrpe.cfg.
+
 ## 2.2.0 - 2017-09-28
 
 ### Changed

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'blp-nrpe'
-version '2.2.1'
+version '2.2.2'
 maintainer 'Bloomberg Finance L.P.'
 maintainer_email 'chef@bloomberg.net'
 license 'Apache-2.0'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -37,6 +37,8 @@ def content
 
   properties.map do |p|
     next unless p.get(self)
+    next if platform_family?('solaris2') && p.name.to_s == 'allow_bash_commands'
+
     "#{p.name}=#{p.get(self)}"
   end.compact.join("\n")
 end


### PR DESCRIPTION
### Description

Skip allow_bash_commands option in nrpe.cfg for Solaris machines. 

### Issues Resolved

allow_bash_commands option is unsupported by nrpe on Solaris.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
