### PR TITLE
use newer oses for testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,7 +46,7 @@ platforms:
     named_run_list: debian
     driver:
       image: dokken/ubuntu-20.04
-      pid_one_command: /lib/bin/systemd
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ platforms:
     named_run_list: debian
     driver:
       image: ubuntu:18.04
-      pid_one_command: /bin/systemd
+      pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
@@ -46,7 +46,7 @@ platforms:
     named_run_list: debian
     driver:
       image: ubuntu:20.04
-      pid_one_command: /bin/systemd
+      pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ platforms:
   - name: centos-7
     named_run_list: centos
     driver:
-      image: centos:7
+      image: centos/7
       platform: rhel
       pid_one_command: /sbin/init
       intermediate_instructions:
@@ -27,7 +27,7 @@ platforms:
   - name: centos-8
     named_run_list: centos
     driver:
-      image: centos:8
+      image: centos/8
       platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
@@ -36,8 +36,8 @@ platforms:
   - name: ubuntu-18.04
     named_run_list: debian
     driver:
-      image: ubuntu:18.04
-      pid_one_command: /sbin/init
+      image: ubuntu/18.04
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
@@ -45,8 +45,8 @@ platforms:
   - name: ubuntu-20.04
     named_run_list: debian
     driver:
-      image: ubuntu:20.04
-      pid_one_command: /sbin/init
+      image: ubuntu/20.04
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,6 @@
 driver:
   name: dokken
-  chef_version: 14.12.3
+  chef_version: 14.14.25
   privileged: true
 
 transport:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,41 +18,34 @@ platforms:
   - name: centos-7
     named_run_list: centos
     driver:
-      image: centos:7
+      image: dokken/centos-7
       platform: rhel
-      pid_one_command: /sbin/init
+      pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN yum -y install lsof which initscripts net-tools sudo wget
 
   - name: centos-8
     named_run_list: centos
     driver:
-      image: centos:8
+      image: dokken/centos-8
       platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
-        - RUN yum -y install lsof which systemd-sysv initscripts net-tools sudo wget
+        - RUN yum -y install lsof which initscripts net-tools sudo wget
 
   - name: ubuntu-18.04
     named_run_list: debian
     driver:
-      image: ubuntu:18.04
-      pid_one_command: /lib/systemd/systemd
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
-    lifecycle:
-      post_create:
-      - local: echo testing for various init systems
-      - remote: stat /bin/systemd
-      - remote: stat /sbin/init
-      - remote: stat /lib/systemd/systemd
-      
       
   - name: ubuntu-20.04
     named_run_list: debian
     driver:
-      image: ubuntu:20.04
+      image: dokken/ubuntu-20.04
       pid_one_command: /lib/bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,16 +37,23 @@ platforms:
     named_run_list: debian
     driver:
       image: ubuntu:18.04
-      pid_one_command: /bin/systemd
+      pid_one_command: /lib/systemd/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
-        
+    lifecycle:
+      post_create:
+      - local: echo testing for various init systems
+      - remote: stat /bin/systemd
+      - remote: stat /sbin/init
+      - remote: stat /lib/systemd/systemd
+      
+      
   - name: ubuntu-20.04
     named_run_list: debian
     driver:
       image: ubuntu:20.04
-      pid_one_command: /bin/systemd
+      pid_one_command: /lib/bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,55 +15,37 @@ verifier:
   name: inspec
 
 platforms:
-  - name: centos-6
-    named_run_list: centos
-    driver:
-      image: centos:6
-      platform: rhel
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN yum -y install lsof which initscripts net-tools sudo wget
-
   - name: centos-7
     named_run_list: centos
     driver:
       image: centos:7
       platform: rhel
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN yum -y install lsof which initscripts net-tools sudo wget
+
+  - name: centos-8
+    named_run_list: centos
+    driver:
+      image: centos:8
+      platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         - RUN yum -y install lsof which systemd-sysv initscripts net-tools sudo wget
 
-  - name: ubuntu-12.04
+  - name: ubuntu-18.04
     named_run_list: debian
     driver:
-      image: ubuntu-upstart:12.04
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
-
-  - name: ubuntu-14.04
-    named_run_list: debian
-    driver:
-      image: ubuntu-upstart:14.04
-      pid_one_command: /sbin/init
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
-
-  - name: ubuntu-16.04
-    named_run_list: debian
-    driver:
-      image: ubuntu:16.04
+      image: ubuntu:18.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools sudo -y
         
-  - name: ubuntu-18.04
+  - name: ubuntu-20.04
     named_run_list: debian
     driver:
-      image: ubuntu:18.04
+      image: ubuntu:20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ platforms:
   - name: centos-7
     named_run_list: centos
     driver:
-      image: centos/7
+      image: centos:7
       platform: rhel
       pid_one_command: /sbin/init
       intermediate_instructions:
@@ -27,7 +27,7 @@ platforms:
   - name: centos-8
     named_run_list: centos
     driver:
-      image: centos/8
+      image: centos:8
       platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
@@ -36,7 +36,7 @@ platforms:
   - name: ubuntu-18.04
     named_run_list: debian
     driver:
-      image: ubuntu/18.04
+      image: ubuntu:18.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -45,7 +45,7 @@ platforms:
   - name: ubuntu-20.04
     named_run_list: debian
     driver:
-      image: ubuntu/20.04
+      image: ubuntu:20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
-dist: trusty
+dist: bionic
 group: edge
 
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-bionic
     packages:
       - chefdk
 
@@ -21,9 +21,8 @@ env:
   matrix:
     - INSTANCE=default-centos-6
     - INSTANCE=default-centos-7
-    - INSTANCE=default-ubuntu-1204
-    - INSTANCE=default-ubuntu-1404
-    - INSTANCE=default-ubuntu-1604
+    - INSTANCE=default-ubuntu-1804
+    - INSTANCE=default-ubuntu-2004
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - chef --version
   - cookstyle --version
   - foodcritic --version
+  - kitchen destroy ${INSTANCE}
 
 script: kitchen verify ${INSTANCE}
 after_script: cat .kitchen/logs/kitchen.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ before_script:
   - chef --version
   - cookstyle --version
   - foodcritic --version
-  - kitchen destroy ${INSTANCE}
 
-script: kitchen verify ${INSTANCE}
+script: kitchen test ${INSTANCE}
 after_script: cat .kitchen/logs/kitchen.log
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ services: docker
 
 env:
   matrix:
-    - INSTANCE=default-centos-6
     - INSTANCE=default-centos-7
+    - INSTANCE=default-centos-8
     - INSTANCE=default-ubuntu-1804
     - INSTANCE=default-ubuntu-2004
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: required
 dist: bionic
 group: edge
 
-addons:
-  apt:
-    sources:
-      - chef-current-bionic
-    packages:
-      - chefdk-3.11.3
+before_install:
+  - wget https://packages.chef.io/files/stable/chefdk/3.11.3/ubuntu/18.04/chefdk_3.11.3-1_amd64.deb
+  - sudo dpkg -i chefdk_3.11.3-1_amd64.deb
 
 install: echo "skip bundle install"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     sources:
       - chef-current-bionic
     packages:
-      - chefdk
+      - chefdk-3.11.3
 
 install: echo "skip bundle install"
 


### PR DESCRIPTION
### Description

update travis to use newer ubuntu and centos versions.

update the chef-client target version for testing to 14.14.25

force use chefdk 3.11.3 for travis

### Issues Resolved

travis _**will**_ start working again

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
